### PR TITLE
Enchantment table support + Interaction fixes

### DIFF
--- a/src/RedCraftPE/RedSkyBlock/EventListener.php
+++ b/src/RedCraftPE/RedSkyBlock/EventListener.php
@@ -126,8 +126,9 @@ class EventListener implements Listener {
     $block = $event->getBlock();
     $item = $event->getItem();
     $plugin = $this->plugin;
+    if($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK){
 
-    if ($block->getID() === 52 ||$block->getID() === 54 || $block->getID() === 61 || $block->getID() === 62 || $block->getID() === 138 || $block->getID() === 130 || $item->getID() === 259 || $block->getID() === 145 || $block->getID() === 58 || $block->getID() === 154 || $block->getID() === 117) {
+    if ($block->getID() === 116 || $block->getID() === 52 || $block->getID() === 54 || $block->getID() === 61 || $block->getID() === 62 || $block->getID() === 138 || $block->getID() === 130 || $item->getID() === 259 || $block->getID() === 145 || $block->getID() === 58 || $block->getID() === 154 || $block->getID() === 117) {
 
       if ($player->getLevel()->getFolderName() === $plugin->skyblock->get("Master World") || $player->getLevel()->getFolderName() === $plugin->skyblock->get("Master World") . "-Nether") {
 
@@ -162,6 +163,7 @@ class EventListener implements Listener {
         }
       }
     }
+  }
   }
   public function onBucketEvent(PlayerBucketEvent $event) {
 


### PR DESCRIPTION
So I was looking around this plugin. It's pretty nice. Now, I did notice some issues with Enchantment tables being interactable. Although, enchantment tables have no use from default pocketmine, other server owners may introduce enchantment table support such as VanillaInventory plugin, which supports enchantment table and anvils. This commit makes it so enchantment tables aren't interactable, and it requires a right click to open. Because I don't see why you would left click things like chests, enchantment tables, anvils, crafting tables, etc. So I've made it so you have to right click to see if a message pops up. This is more better than spammy messages (twice per hit whilst in creative).